### PR TITLE
a10s: fix MTP on Galaxy A10s while using GSI

### DIFF
--- a/drivers/usb/gadget/function/Makefile
+++ b/drivers/usb/gadget/function/Makefile
@@ -50,13 +50,8 @@ usb_f_adm-y			:= f_adm.o
 obj-$(CONFIG_USB_CONFIGFS_F_ADM)	+= usb_f_adm.o
 usb_f_tcm-y			:= f_tcm.o
 obj-$(CONFIG_USB_F_TCM)		+= usb_f_tcm.o
-ifeq ($(CONFIG_USB_ANDROID_SAMSUNG_COMPOSITE),y)
-	usb_f_mtp_samsung-y     := f_mtp_samsung.o
-	obj-$(CONFIG_USB_F_MTP) += usb_f_mtp_samsung.o
-else
-	usb_f_mtp-y             := f_mtp.o
-        obj-$(CONFIG_USB_F_MTP) += usb_f_mtp.o
-endif
+usb_f_mtp-y                     := f_mtp.o
+obj-$(CONFIG_USB_F_MTP)         += usb_f_mtp.o
 usb_f_ptp-y                     := f_ptp.o
 obj-$(CONFIG_USB_F_PTP)         += usb_f_ptp.o
 usb_f_audio_source-y            := f_audio_source.o

--- a/drivers/usb/gadget/function/f_mtp.c
+++ b/drivers/usb/gadget/function/f_mtp.c
@@ -39,7 +39,7 @@
 #include <linux/configfs.h>
 #include <linux/usb/composite.h>
 
-#include "configfs.h"
+#include "../configfs.h"
 #ifdef CONFIG_MEDIATEK_SOLUTION
 #include "usb_boost.h"
 //#include "aee.h"

--- a/drivers/usb/gadget/function/f_mtp.c
+++ b/drivers/usb/gadget/function/f_mtp.c
@@ -821,7 +821,17 @@ static ssize_t mtp_read(struct file *fp, char __user *buf,
 	cdev = dev->cdev;
 
 	spin_lock_irq(&dev->lock);
+	if (dev->state == STATE_OFFLINE) {
+		spin_unlock_irq(&dev->lock);
+		return -ENODEV;
+	}
+
 	if (dev->ep_out->desc) {
+		if (!cdev) {
+			spin_unlock_irq(&dev->lock);
+			return -ENODEV;
+		}
+
 		len = usb_ep_align_maybe(cdev->gadget, dev->ep_out, count);
 		if (len > MTP_BULK_BUFFER_SIZE) {
 			spin_unlock_irq(&dev->lock);
@@ -2017,7 +2027,10 @@ mtp_function_unbind(struct usb_configuration *c, struct usb_function *f)
 		mtp_request_free(dev->rx_req[i], dev->ep_out);
 	while ((req = mtp_req_get(dev, &dev->intr_idle)))
 		mtp_request_free(req, dev->ep_intr);
+	spin_lock_irq(&dev->lock);
 	dev->state = STATE_OFFLINE;
+	dev->cdev = NULL;
+	spin_unlock_irq(&dev->lock);
 	kfree(f->os_desc_table);
 	f->os_desc_n = 0;
 }
@@ -2072,7 +2085,9 @@ static void mtp_function_disable(struct usb_function *f)
 	struct usb_composite_dev	*cdev = dev->cdev;
 
 	DBG(cdev, "mtp_function_disable\n");
+	spin_lock_irq(&dev->lock);
 	dev->state = STATE_OFFLINE;
+	spin_unlock_irq(&dev->lock);
 	usb_ep_disable(dev->ep_in);
 	usb_ep_disable(dev->ep_out);
 	usb_ep_disable(dev->ep_intr);


### PR DESCRIPTION
- mtp: force generic mtp driver instead of Samsung one
- usb: gadget: f_mtp: Avoid race between mtp_read and mtp_function_disable
